### PR TITLE
Added memory trash detection

### DIFF
--- a/include/ace/managers/memory.h
+++ b/include/ace/managers/memory.h
@@ -41,6 +41,8 @@ void _memFreeDbg(void *pMem, ULONG ulSize, UWORD uwLine, char *szFile);
 void *_memAllocRls(ULONG ulSize, ULONG ulFlags);
 void _memFreeRls(void *pMem, ULONG ulSize);
 
+void _memCheckTrash(void *pMem, UWORD uwLine, char *szFile);
+
 /**
  * Macros for enabling or disabling logging
  */
@@ -52,6 +54,7 @@ void _memFreeRls(void *pMem, ULONG ulSize);
 # define memDestroy() _memDestroy()
 # define memEntryAdd(pAddr, ulSize) _memEntryAdd(pAddr, ulSize, __LINE__, __FILE__)
 # define memEntryDelete(pAddr, ulSize) _memEntryDelete(pAddr, ulSize, __LINE__, __FILE__)
+# define memCheckTrash(pAddr) _memCheckTrash(pAddr, __LINE__, __FILE__)
 #else
 # define memAlloc(ulSize, ulFlags) _memAllocRls(ulSize, ulFlags)
 # define memFree(pMem, ulSize) _memFreeRls(pMem, ulSize)
@@ -59,6 +62,7 @@ void _memFreeRls(void *pMem, ULONG ulSize);
 # define memDestroy()
 # define memEntryAdd(pAddr, ulSize)
 # define memEntryDelete(pAddr, ulSize)
+# define memCheckTrash(pAddr, ulSize)
 #endif // ACE_DEBUG
 
 // Shorthands

--- a/src/ace/managers/memory.c
+++ b/src/ace/managers/memory.c
@@ -144,7 +144,7 @@ void _memDestroy(void) {
 
 void *_memAllocDbg(ULONG ulSize, ULONG ulFlags, UWORD uwLine, char *szFile) {
 	void *pAddr;
-	pAddr = _memAllocRls(ulSize, ulFlags);
+	pAddr = _memAllocRls(ulSize + 2*sizeof(ULONG), ulFlags);
 	if(!pAddr) {
 		filePrintf(
 			s_pMemLog, "ERR: couldn't allocate %lu bytes! (%s:%u)\n",
@@ -164,13 +164,19 @@ void *_memAllocDbg(ULONG ulSize, ULONG ulFlags, UWORD uwLine, char *szFile) {
 #endif // AMIGA
 		return 0;
 	}
+	pAddr += sizeof(ULONG);
+	ULONG *pCafe = (ULONG*)(pAddr - sizeof(ULONG));
+	ULONG *pDead = (ULONG*)(pAddr + ulSize);
+	*pCafe = 0xCAFEBABE;
+	*pDead = 0xDEADBEEF;
 	_memEntryAdd(pAddr, ulSize, uwLine, szFile);
 	return pAddr;
 }
 
 void _memFreeDbg(void *pMem, ULONG ulSize, UWORD uwLine, char *szFile) {
+	_memCheckTrash(pMem, uwLine, szFile);
 	_memEntryDelete(pMem, ulSize, uwLine, szFile);
-	_memFreeRls(pMem, ulSize);
+	_memFreeRls(pMem - sizeof(ULONG), ulSize + 2*sizeof(ULONG));
 }
 
 void *_memAllocRls(ULONG ulSize, ULONG ulFlags) {
@@ -193,4 +199,37 @@ void _memFreeRls(void *pMem, ULONG ulSize) {
 	free(pMem);
 	#endif // AMIGA
 	systemUnuse();
+}
+
+void _memCheckTrash(void *pMem, UWORD uwLine, char *szFile) {
+	// find memory entry
+	tMemEntry *pEntry = s_pMemTail;
+	while(pEntry && pEntry->pAddr != pMem) {
+		pEntry = pEntry->pNext;
+	}
+	if(pEntry->pAddr != pMem) {
+		filePrintf(
+			s_pMemLog, "ERR: can't find memory allocated at %p (%s:%u)\n",
+			pMem, szFile, uwLine
+		);
+		fileFlush(s_pMemLog);
+		return;
+	}
+
+	ULONG *pCafe = (ULONG*)(pMem - sizeof(ULONG));
+	ULONG *pDead = (ULONG*)(pMem + pEntry->ulSize);
+	if(*pCafe != 0xCAFEBABE) {
+		filePrintf(
+			s_pMemLog, "ERR: Left mem trashed: %hu@%p (%s:%u)\n",
+			pEntry->uwId, pMem, uwLine, szFile
+		);
+		fileFlush(s_pMemLog);
+	}
+	if(*pDead != 0xDEADBEEF) {
+		filePrintf(
+			s_pMemLog, "ERR: Right mem trashed: %hu%p (%s:%u)\n",
+			pEntry->uwId, pMem, uwLine, szFile
+		);
+		fileFlush(s_pMemLog);
+	}
 }

--- a/src/ace/managers/memory.c
+++ b/src/ace/managers/memory.c
@@ -144,7 +144,7 @@ void _memDestroy(void) {
 
 void *_memAllocDbg(ULONG ulSize, ULONG ulFlags, UWORD uwLine, char *szFile) {
 	void *pAddr;
-	pAddr = _memAllocRls(ulSize + 2*sizeof(ULONG), ulFlags);
+	pAddr = _memAllocRls(ulSize + 2 * sizeof(ULONG), ulFlags);
 	if(!pAddr) {
 		filePrintf(
 			s_pMemLog, "ERR: couldn't allocate %lu bytes! (%s:%u)\n",
@@ -176,7 +176,7 @@ void *_memAllocDbg(ULONG ulSize, ULONG ulFlags, UWORD uwLine, char *szFile) {
 void _memFreeDbg(void *pMem, ULONG ulSize, UWORD uwLine, char *szFile) {
 	_memCheckTrash(pMem, uwLine, szFile);
 	_memEntryDelete(pMem, ulSize, uwLine, szFile);
-	_memFreeRls(pMem - sizeof(ULONG), ulSize + 2*sizeof(ULONG));
+	_memFreeRls(pMem - sizeof(ULONG), ulSize + 2 * sizeof(ULONG));
 }
 
 void *_memAllocRls(ULONG ulSize, ULONG ulFlags) {


### PR DESCRIPTION
Eases out-of-bounds debugging in heap-allocated regions.

Right trashing occurs mostly when array indices become bigger than array size. Left trashes are more tricky to interpret, but are indicating that something's wrong is going on in memory.